### PR TITLE
Update Kotlin version to use the same than in Kassava project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 sudo: true
-jdk: oraclejdk8
+jdk: openjdk8
 script: mvn clean package && java -jar target/benchmarks.jar -wi 10 -i 5 -f 1 -tu ns -bm avgt

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,13 @@
     <name>Kassava benchmarks</name>
 
     <properties>
-        <kotlin.version>1.0.6</kotlin.version>
+        <javac.target>1.8</javac.target>
+        <kotlin.version>1.3.61</kotlin.version>
+        <kotlin.compiler.jvmTarget>${javac.target}</kotlin.compiler.jvmTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kassava.version>1.0.0</kassava.version>
-        <jmh.version>1.17.3</jmh.version>
+        <jmh.version>1.23</jmh.version>
         <jmh.generator>default</jmh.generator>
-        <javac.target>1.8</javac.target>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
 


### PR DESCRIPTION
- Also update jmh version
- Set Kotlin JVM target at the same version that in Kassava project so then inline functions was compatible

The update of Kotlin version is also needed to use with JVM 11 (use of unsafe above the JVM 9) 